### PR TITLE
Adjust discriminator and pre-training for 7-feature hub graphs

### DIFF
--- a/discriminator.py
+++ b/discriminator.py
@@ -10,9 +10,14 @@ import torch.nn.functional as F
 
 
 class HubDetectionDiscriminator(nn.Module):
-    """Enhanced discriminator for hub detection with improved architecture"""
+    """Enhanced discriminator for hub detection with improved architecture.
 
-    def __init__(self, node_dim: int, edge_dim: int, hidden_dim: int = 128,
+    The model now defaults to graphs that provide only node features (no edge
+    attributes) which matches the new 1-hop subgraph dataset with seven node
+    features per node.
+    """
+
+    def __init__(self, node_dim: int, edge_dim: int = 0, hidden_dim: int = 128,
                  num_layers: int = 4, dropout: float = 0.2, heads: int = 8):
         super().__init__()
 


### PR DESCRIPTION
## Summary
- default discriminator to node-only graphs matching new 1-hop dataset
- simplify pre-training to load 7-feature hub-focused data and update cross-validation

## Testing
- `python -m py_compile discriminator.py pre-training-discriminator.py`
- `python pre-training-discriminator.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy --quiet` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890b036ec108329aa2a122d329eb7a1