### PR TITLE
Use 7 feature input for discriminator

### DIFF
--- a/discriminator.py
+++ b/discriminator.py
@@ -10,9 +10,12 @@ import torch.nn.functional as F
 
 
 class HubDetectionDiscriminator(nn.Module):
-    """Enhanced discriminator for hub detection with improved architecture"""
+    """Enhanced discriminator for hub detection with improved architecture.
 
-    def __init__(self, node_dim: int, edge_dim: int, hidden_dim: int = 128,
+    By default expects 7 node features and 1 edge feature.
+    """
+
+    def __init__(self, node_dim: int = 7, edge_dim: int = 1, hidden_dim: int = 128,
                  num_layers: int = 4, dropout: float = 0.2, heads: int = 8):
         super().__init__()
 

--- a/pre-training-discriminator.py
+++ b/pre-training-discriminator.py
@@ -622,7 +622,7 @@ def k_fold_cross_validation(data: List[Data], labels: List[int],
 
         # Create enhanced model for this fold with FIXED dimensions
         model = HubDetectionDiscriminator(
-            node_dim=node_dim,  # Always 14
+            node_dim=7,
             edge_dim=edge_dim,  # Always 1
             hidden_dim=128,
             num_layers=4,
@@ -688,7 +688,7 @@ def train_final_model(data: List[Data], labels: List[int], device: torch.device,
 
     # Create enhanced model with FIXED dimensions
     model = HubDetectionDiscriminator(
-        node_dim=node_dim,
+        node_dim=7,
         edge_dim=edge_dim,
         hidden_dim=128,
         num_layers=4,


### PR DESCRIPTION
## Summary
- configure discriminator to default to 7 node features
- pretraining script explicitly passes `node_dim=7`

## Testing
- `python -m py_compile pre-training-discriminator.py discriminator.py`

------
https://chatgpt.com/codex/tasks/task_e_6890b19e74fc8329b1b34639abb5efc0