### PR TITLE
Validate LR bounds and track per-step learning rates

### DIFF
--- a/train_main.py
+++ b/train_main.py
@@ -785,6 +785,12 @@ def main():
             final_lr_actor = trainer.actor_scheduler.get_last_lr()[0]
             final_lr_critic = trainer.critic_scheduler.get_last_lr()[0]
             print(f"📈 Final LRs - Actor: {final_lr_actor:.2e}, Critic: {final_lr_critic:.2e}")
+            lr_stats = getattr(trainer, 'lr_stats', None)
+            if lr_stats:
+                print(
+                    f"   Actor LR range: {lr_stats['actor_min']:.2e} - {lr_stats['actor_max']:.2e}")
+                print(
+                    f"   Critic LR range: {lr_stats['critic_min']:.2e} - {lr_stats['critic_max']:.2e}")
 
     except KeyboardInterrupt:
         print("⏹️  Training interrupted by user")


### PR DESCRIPTION
## Summary
- Enforce `base_lr < max_lr` for actor and critic before optimizer and scheduler creation
- Step learning-rate schedulers after each optimizer step and log actor/critic LR every update while tracking min/max ranges
- Surface final actor and critic learning-rate ranges at training completion

## Testing
- `python -m py_compile a2c_trainer.py train_main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898da7689008329a29b8bf1dabc149c